### PR TITLE
Added support for android.os.Looper and Activity::getApplication

### DIFF
--- a/src/soot/jimple/infoflow/entryPointCreators/AndroidEntryPointCreator.java
+++ b/src/soot/jimple/infoflow/entryPointCreators/AndroidEntryPointCreator.java
@@ -38,6 +38,7 @@ import soot.jimple.Jimple;
 import soot.jimple.JimpleBody;
 import soot.jimple.NopStmt;
 import soot.jimple.Stmt;
+import soot.jimple.infoflow.cfg.LibraryClassPatcher;
 import soot.jimple.infoflow.data.SootMethodAndClass;
 import soot.jimple.infoflow.util.SootMethodRepresentationParser;
 import soot.jimple.internal.JAssignStmt;
@@ -249,6 +250,17 @@ public class AndroidEntryPointCreator extends BaseEntryPointCreator implements I
 					// Call the onCreate() method
 					searchAndBuildMethod(AndroidEntryPointConstants.APPLICATION_ONCREATE,
 							applicationClass, entry.getValue(), applicationLocal);
+					
+					//////////////
+					// Initializes the ApplicationHolder static field with the singleton application 
+					// instance created above 
+					// (Used by the Activity::getApplication patched in LibraryClassPatcher)
+					SootClass scApplicationHolder = LibraryClassPatcher.createOrGetApplicationHolder();
+					body.getUnits().add(Jimple.v().newAssignStmt(
+							Jimple.v().newStaticFieldRef(scApplicationHolder.getFields().getFirst().makeRef()), 
+							applicationLocal));
+					//////////////
+					
 					break;
 				}
 		}

--- a/src/soot/jimple/infoflow/taintWrappers/EasyTaintWrapper.java
+++ b/src/soot/jimple/infoflow/taintWrappers/EasyTaintWrapper.java
@@ -428,7 +428,7 @@ public class EasyTaintWrapper extends AbstractTaintWrapper implements Cloneable 
 		SootMethod method = stmt.getInvokeExpr().getMethod();
 		
 		// Do we have an entry for at least one entry in the given class?
-		if (hasWrappedMethodsForClass(method.getDeclaringClass(), true, true, true))
+		if (hasWrappedMethodsForClass(method.getDeclaringClass(), true, true, false))
 			return true;
 
 		// In aggressive mode, we always taint the return value if the base


### PR DESCRIPTION
- Added support for android.os.Looper (Handler dispatchMessage method) - tested on the DroidBench case successfully. (Looper1)
- Added support for Activity::getApplication (Now the singleton instance created in the dummy main is returned in the getApplication method) - note: I tested it againt a apk I compiled with the code in the DroidBench case. (ApplicationModeling1)

Attached a detailed PDF describing our work.
[FlowDroidShortVersion.pdf](https://github.com/secure-software-engineering/soot-infoflow/files/212031/FlowDroidShortVersion.pdf)
