### PR TITLE
Support for geom-pta call graph construction

### DIFF
--- a/src/soot/jimple/infoflow/AbstractInfoflow.java
+++ b/src/soot/jimple/infoflow/AbstractInfoflow.java
@@ -208,14 +208,13 @@ public abstract class AbstractInfoflow implements IInfoflow {
 				// SPARK fails due to the missing allocation site and we fall
 				// back to CHA.
 				if (extraSeed == null || extraSeed.isEmpty()) {
-					Options.v().setPhaseOption("cg.spark", "on");
-					Options.v().setPhaseOption("cg.spark", "string-constants:true");
+					setSparkOptions();
+				} else {
+					setChaOptions();
 				}
-				else
-					Options.v().setPhaseOption("cg.cha", "on");
 				break;
 			case CHA:
-				Options.v().setPhaseOption("cg.cha", "on");
+				setChaOptions();
 				break;
 			case RTA:
 				Options.v().setPhaseOption("cg.spark", "on");
@@ -229,8 +228,11 @@ public abstract class AbstractInfoflow implements IInfoflow {
 				Options.v().setPhaseOption("cg.spark", "string-constants:true");
 				break;
 			case SPARK:
-				Options.v().setPhaseOption("cg.spark", "on");
-				Options.v().setPhaseOption("cg.spark", "string-constants:true");
+				setSparkOptions();
+				break;
+			case GEOM:
+				setSparkOptions();
+				setGeomPtaSpecificOptions();
 				break;
 			case OnDemand:
 				// nothing to set here
@@ -281,7 +283,24 @@ public abstract class AbstractInfoflow implements IInfoflow {
 			return;
 		}
 	}
-	
+
+	private void setChaOptions() {
+		Options.v().setPhaseOption("cg.cha", "on");
+	}
+
+	private void setSparkOptions() {
+		Options.v().setPhaseOption("cg.spark", "on");
+		Options.v().setPhaseOption("cg.spark", "string-constants:true");
+	}
+
+	public static void setGeomPtaSpecificOptions() {
+		Options.v().setPhaseOption("cg.spark", "geom-pta:true");
+
+		//options below should be optional, yet they aren't set anywhere in soot.
+		Options.v().setPhaseOption("cg.spark", "geom-encoding:Geom");
+		Options.v().setPhaseOption("cg.spark", "geom-worklist:PQ");
+	}
+
 	@Override
 	public void setSootConfig(IInfoflowConfig config) {
 		sootConfig = config;

--- a/src/soot/jimple/infoflow/AbstractInfoflow.java
+++ b/src/soot/jimple/infoflow/AbstractInfoflow.java
@@ -296,9 +296,13 @@ public abstract class AbstractInfoflow implements IInfoflow {
 	public static void setGeomPtaSpecificOptions() {
 		Options.v().setPhaseOption("cg.spark", "geom-pta:true");
 
-		//options below should be optional, yet they aren't set anywhere in soot.
+		//options below should be optional, yet they aren't set anywhere in Soot.
 		Options.v().setPhaseOption("cg.spark", "geom-encoding:Geom");
 		Options.v().setPhaseOption("cg.spark", "geom-worklist:PQ");
+		//Options.v().setPhaseOption("cg.spark", "dump-html:true");
+		//Options.v().setPhaseOption("cg.spark", "geom-dump-verbose:sootOutput");
+		//Options.v().setPhaseOption("cg.spark", "geom-runs:3");
+		//Options.v().setPhaseOption("cg.spark", "geom-frac-base:100");
 	}
 
 	@Override

--- a/src/soot/jimple/infoflow/AbstractInfoflow.java
+++ b/src/soot/jimple/infoflow/AbstractInfoflow.java
@@ -296,13 +296,9 @@ public abstract class AbstractInfoflow implements IInfoflow {
 	public static void setGeomPtaSpecificOptions() {
 		Options.v().setPhaseOption("cg.spark", "geom-pta:true");
 
-		//options below should be optional, yet they aren't set anywhere in Soot.
+		//Those are default options, not sure whether removing them works.
 		Options.v().setPhaseOption("cg.spark", "geom-encoding:Geom");
 		Options.v().setPhaseOption("cg.spark", "geom-worklist:PQ");
-		//Options.v().setPhaseOption("cg.spark", "dump-html:true");
-		//Options.v().setPhaseOption("cg.spark", "geom-dump-verbose:sootOutput");
-		//Options.v().setPhaseOption("cg.spark", "geom-runs:3");
-		//Options.v().setPhaseOption("cg.spark", "geom-frac-base:100");
 	}
 
 	@Override

--- a/src/soot/jimple/infoflow/Infoflow.java
+++ b/src/soot/jimple/infoflow/Infoflow.java
@@ -211,7 +211,7 @@ public class Infoflow extends AbstractInfoflow {
 		// Build the callgraph
 		long beforeCallgraph = System.nanoTime();
 		constructCallgraph();
-		logger.info("Cakkgraph construction took " + (System.nanoTime() - beforeCallgraph) / 1E9
+		logger.info("Callgraph construction took " + (System.nanoTime() - beforeCallgraph) / 1E9
 				+ " seconds");
 
         // Perform constant propagation and remove dead code

--- a/src/soot/jimple/infoflow/InfoflowConfiguration.java
+++ b/src/soot/jimple/infoflow/InfoflowConfiguration.java
@@ -89,6 +89,8 @@ public class InfoflowConfiguration {
 	private CallgraphAlgorithm callgraphAlgorithm = CallgraphAlgorithm.AutomaticSelection;
 	private AliasingAlgorithm aliasingAlgorithm = AliasingAlgorithm.FlowSensitive;
 	private CodeEliminationMode codeEliminationMode = CodeEliminationMode.PropagateConstants;
+
+	private boolean taintAnalysisEnabled = true;
 	
 	/**
 	 * Merges the given configuration options into this configuration object
@@ -536,7 +538,15 @@ public class InfoflowConfiguration {
 	public void setLogSourcesAndSinks(boolean logSourcesAndSinks) {
 		this.logSourcesAndSinks = logSourcesAndSinks;
 	}
-	
+
+	public boolean isTaintAnalysisEnabled() {
+		return taintAnalysisEnabled;
+	}
+
+	public void setTaintAnalysisEnabled(boolean taintAnalysisEnabled) {
+		this.taintAnalysisEnabled = taintAnalysisEnabled;
+	}
+
 	/**
 	 * Prints a summary of this data flow configuration
 	 */
@@ -562,6 +572,7 @@ public class InfoflowConfiguration {
 			logger.info("Recursive access path shortening is enabled");
 		else
 			logger.info("Recursive access path shortening is NOT enabled");
+		logger.info("Taint analysis enabled: " + taintAnalysisEnabled);
 	}
 	
 }

--- a/src/soot/jimple/infoflow/InfoflowConfiguration.java
+++ b/src/soot/jimple/infoflow/InfoflowConfiguration.java
@@ -24,6 +24,7 @@ public class InfoflowConfiguration {
 		VTA,
 		RTA,
 		SPARK,
+		GEOM,
 		OnDemand
 	}
 	


### PR DESCRIPTION
1. Support for geom-pta call graph construction.
2. A config option to disable taint analysis, for whoever want to use the rest of FlowDroid only.
3. Some minor logs and deleted white spaces (sorry about that, that's what Intellij is doing).