### PR TITLE
Attempts to fix a source of non-determinism in flowdroid

### DIFF
--- a/src/soot/jimple/infoflow/Infoflow.java
+++ b/src/soot/jimple/infoflow/Infoflow.java
@@ -59,6 +59,7 @@ import soot.jimple.infoflow.results.ResultSourceInfo;
 import soot.jimple.infoflow.solver.IMemoryManager;
 import soot.jimple.infoflow.solver.cfg.BackwardsInfoflowCFG;
 import soot.jimple.infoflow.solver.cfg.IInfoflowCFG;
+import soot.jimple.infoflow.solver.fastSolver.BackwardsInfoflowSolver;
 import soot.jimple.infoflow.solver.fastSolver.InfoflowSolver;
 import soot.jimple.infoflow.source.ISourceSinkManager;
 import soot.jimple.infoflow.util.SootMethodRepresentationParser;
@@ -257,7 +258,7 @@ public class Infoflow extends AbstractInfoflow {
 				backwardsManager = new InfoflowManager(config, null,
 						new BackwardsInfoflowCFG(iCfg), sourcesSinks, taintWrapper);
 				backProblem = new BackwardsInfoflowProblem(backwardsManager);
-				backSolver = new InfoflowSolver(backProblem, executor);
+				backSolver = new BackwardsInfoflowSolver(backProblem, executor);
 				backSolver.setMemoryManager(memoryManager);
 				backSolver.setJumpPredecessors(!pathBuilderFactory.supportsPathReconstruction());
 //				backSolver.setEnableMergePointChecking(true);

--- a/src/soot/jimple/infoflow/solver/fastSolver/BackwardsInfoflowSolver.java
+++ b/src/soot/jimple/infoflow/solver/fastSolver/BackwardsInfoflowSolver.java
@@ -1,0 +1,56 @@
+package soot.jimple.infoflow.solver.fastSolver;
+
+import heros.FlowFunction;
+import heros.solver.CountingThreadPoolExecutor;
+import heros.solver.Pair;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+import soot.SootMethod;
+import soot.Unit;
+import soot.jimple.infoflow.data.Abstraction;
+import soot.jimple.infoflow.problems.AbstractInfoflowProblem;
+import soot.jimple.infoflow.solver.IInfoflowSolver;
+
+public class BackwardsInfoflowSolver extends InfoflowSolver {
+	public BackwardsInfoflowSolver(AbstractInfoflowProblem problem, CountingThreadPoolExecutor executor) {
+		super(problem, executor);
+	}
+
+	@Override
+	public void injectContext(IInfoflowSolver otherSolver, SootMethod callee,
+			Abstraction d3, Unit callSite, Abstraction d2, Abstraction d1) {
+		if(!this.addIncoming(callee, d3, callSite, d1, d2)) {
+			return;
+		}
+		Set<Pair<Unit, Abstraction>> endSumm = endSummary(callee, d3);
+		Collection<Unit> returnSiteNs = icfg.getReturnSitesOfCallAt(callSite);
+		
+		if (endSumm != null) {
+			System.err.println("Spawning summary based backwards analysis");
+			for(Pair<Unit, Abstraction> entry: endSumm) {
+				Unit eP = entry.getO1();
+				Abstraction d4 = entry.getO2();
+				//for each return site
+				for(Unit retSiteN: returnSiteNs) {
+					//compute return-flow function
+					FlowFunction<Abstraction> retFunction = flowFunctions.getReturnFlowFunction(callSite, callee, eP, retSiteN);
+					//for each target value of the function
+					for(Abstraction d5: computeReturnFlowFunction(retFunction, d3, d4, callSite, Collections.singleton(d1))) {
+						
+						// If we have not changed anything in the callee, we do not need the facts
+						// from there. Even if we change something: If we don't need the concrete
+						// path, we can skip the callee in the predecessor chain
+						Abstraction d5p = d5;
+						if (d5.equals(d2))
+							d5p = d2;
+						
+						propagate(d1, retSiteN, d5p, callSite, false, true);
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
The backwards alias analysis relies on the incoming edges registered by the forward analysis for returning into caller methods. If an incoming edge to a method is registered with the backwards solver after the backwards solver has processed that method's exit statements then the backwards analysis will never end up returning into that caller and miss taints.

This code snippet demonstrates the issue:

```java
public class Test {
	public static String source() { return ""; }
	public static void sink(final String k) {	}
	public static class Container2 {
		String g;
	}
	public static class X {
		Container2 f;
	}
	public static void doWrite(final X base, final String string) {
		base.f.g = string;
	}
	public static void main(final String[] args) {
		final X base1 = new X();
		final X base2 = new X();
		final String tainted = source();
		doWrite(base1, tainted);
		final Container2 z = base2.f;
		doWrite(base2, tainted);
		sink(z.g);
	}
}
```

When this code is analyzed with the default options on some invocations the flow is discovered others not. (Depending on your machine you may have to add dummy statements between the two calls to doWrite for the non-determinism to appear).

After adding debug statements I've discovered that the situations where the analysis discovers the flow are precisely those situations where the forward solver registers an incoming edge for the second call to doWrite before the backwards solver processes the exit from doWrite.

This commit aims to fix this problem. Let me know of any other improvements that may need to be made!