### PR TITLE
Add Consideration of Fragments from Android Support Library

### DIFF
--- a/src/soot/jimple/infoflow/entryPointCreators/AndroidEntryPointConstants.java
+++ b/src/soot/jimple/infoflow/entryPointCreators/AndroidEntryPointConstants.java
@@ -66,7 +66,7 @@ public class AndroidEntryPointConstants {
 	
 	public static final String FRAGMENT_ONCREATE = "void onCreate(android.os.Bundle)";
 	public static final String FRAGMENT_ONATTACH = "void onAttach(android.app.Activity)";
-	public static final String FRAGMENT_ONCREATEVIEW = "void onCreateView(android.view.LayoutInflater,android.view.ViewGroup,android.os.Bundle)";
+	public static final String FRAGMENT_ONCREATEVIEW = "android.view.View onCreateView(android.view.LayoutInflater,android.view.ViewGroup,android.os.Bundle)";
 	public static final String FRAGMENT_ONVIEWCREATED = "void onViewCreated(android.view.View,android.os.Bundle)";
 	public static final String FRAGMENT_ONSTART = "void onStart()";
 	public static final String FRAGMENT_ONACTIVITYCREATED = "void onActivityCreated(android.os.Bundle)";

--- a/src/soot/jimple/infoflow/entryPointCreators/AndroidEntryPointConstants.java
+++ b/src/soot/jimple/infoflow/entryPointCreators/AndroidEntryPointConstants.java
@@ -28,6 +28,7 @@ public class AndroidEntryPointConstants {
 	public static final String CONTENTPROVIDERCLASS = "android.content.ContentProvider";
 	public static final String APPLICATIONCLASS = "android.app.Application";
 	public static final String FRAGMENTCLASS = "android.app.Fragment";
+	public static final String SUPPORTFRAGMENTCLASS = "android.support.v4.app.Fragment";
 	public static final String SERVICECONNECTIONINTERFACE = "android.content.ServiceConnection";
 	
 	public static final String ACTIVITY_ONCREATE = "void onCreate(android.os.Bundle)";

--- a/src/soot/jimple/infoflow/entryPointCreators/AndroidEntryPointUtils.java
+++ b/src/soot/jimple/infoflow/entryPointCreators/AndroidEntryPointUtils.java
@@ -21,6 +21,7 @@ public class AndroidEntryPointUtils {
 	private SootClass osClassActivity;
 	private SootClass osClassService;
 	private SootClass osClassFragment;
+	private SootClass osClassSupportFragment;
 	private SootClass osClassBroadcastReceiver;
 	private SootClass osClassContentProvider;
 	private SootClass osClassGCMBaseIntentService;
@@ -53,6 +54,7 @@ public class AndroidEntryPointUtils {
 		osClassActivity = Scene.v().getSootClassUnsafe(AndroidEntryPointConstants.ACTIVITYCLASS);
 		osClassService = Scene.v().getSootClassUnsafe(AndroidEntryPointConstants.SERVICECLASS);
 		osClassFragment = Scene.v().getSootClassUnsafe(AndroidEntryPointConstants.FRAGMENTCLASS);
+		osClassSupportFragment = Scene.v().getSootClassUnsafe("android.support.v4.app.Fragment");
 		osClassBroadcastReceiver = Scene.v().getSootClassUnsafe(AndroidEntryPointConstants.BROADCASTRECEIVERCLASS);
 		osClassContentProvider = Scene.v().getSootClassUnsafe(AndroidEntryPointConstants.CONTENTPROVIDERCLASS);
 		osClassGCMBaseIntentService = Scene.v().getSootClassUnsafe(AndroidEntryPointConstants.GCMBASEINTENTSERVICECLASS);
@@ -86,7 +88,9 @@ public class AndroidEntryPointUtils {
 			ctype = ComponentType.Service;
 		// (4) android.app.BroadcastReceiver
 		else if (osClassFragment != null && Scene.v().getOrMakeFastHierarchy().canStoreType(
-			currentClass.getType(), osClassFragment.getType()))
+			     currentClass.getType(), osClassFragment.getType()) || 
+				 osClassSupportFragment != null && Scene.v().getOrMakeFastHierarchy().canStoreType(
+			     currentClass.getType(), osClassSupportFragment.getType()))
 			ctype = ComponentType.Fragment;
 		// (5) android.app.BroadcastReceiver
 		else if (osClassBroadcastReceiver != null && Scene.v().getOrMakeFastHierarchy().canStoreType(

--- a/src/soot/jimple/infoflow/entryPointCreators/AndroidEntryPointUtils.java
+++ b/src/soot/jimple/infoflow/entryPointCreators/AndroidEntryPointUtils.java
@@ -54,7 +54,7 @@ public class AndroidEntryPointUtils {
 		osClassActivity = Scene.v().getSootClassUnsafe(AndroidEntryPointConstants.ACTIVITYCLASS);
 		osClassService = Scene.v().getSootClassUnsafe(AndroidEntryPointConstants.SERVICECLASS);
 		osClassFragment = Scene.v().getSootClassUnsafe(AndroidEntryPointConstants.FRAGMENTCLASS);
-		osClassSupportFragment = Scene.v().getSootClassUnsafe("android.support.v4.app.Fragment");
+		osClassSupportFragment = Scene.v().getSootClassUnsafe(AndroidEntryPointConstants.SUPPORTFRAGMENTCLASS);
 		osClassBroadcastReceiver = Scene.v().getSootClassUnsafe(AndroidEntryPointConstants.BROADCASTRECEIVERCLASS);
 		osClassContentProvider = Scene.v().getSootClassUnsafe(AndroidEntryPointConstants.CONTENTPROVIDERCLASS);
 		osClassGCMBaseIntentService = Scene.v().getSootClassUnsafe(AndroidEntryPointConstants.GCMBASEINTENTSERVICECLASS);


### PR DESCRIPTION
This PR improves the handling of Fragments by considering [Fragments from the Android Support Library](https://developer.android.com/reference/android/support/v4/app/Fragment.html), rather than only checking for standard [Fragments](https://developer.android.com/reference/android/app/Fragment.html).

Additionally, this PR fixes an issue where the subsignature of the Fragment callback method <a href="https://developer.android.com/reference/android/app/Fragment.html#onCreateView(android.view.LayoutInflater, android.view.ViewGroup, android.os.Bundle)">onCreateView</a> has an incorrect return value of "void" (should be "android.view.View"). 

This PR is related to https://github.com/secure-software-engineering/soot-infoflow-android/pull/182